### PR TITLE
Error when running spliceai-wrapper prepare

### DIFF
--- a/spliceai_wrapper/__main__.py
+++ b/spliceai_wrapper/__main__.py
@@ -151,7 +151,7 @@ def prepare(args):
         os.makedirs(os.path.dirname(args.precomputed_db_path), exist_ok=True)
 
     logger.info("Opening database file %s", args.precomputed_db_path)
-    with closing(sqlite3.connect(args.precomputed_db_path), isolation_level=None) as con:
+    with closing(sqlite3.connect(args.precomputed_db_path, isolation_level=None)) as con:
         sql_kwargs = {"release": args.release, "table_name": "spliceai_scores"}
         sql_script = SQL_CREATE_TABLE % sql_kwargs
         logger.info("Executing %s to create table..." % sql_script)


### PR DESCRIPTION
* SpliceAI Wrapper version: 0.1.0
* Python version: 3.6
* Operating System: linux x64

### Description

Error when running spliceai-wrapper prepare, closing function has an additional argument.

### What I Did

```bash
$ spliceai-wrapper prepare --release GRCh38 \
  --precomputed-db-path out/precomputed.sqlite3 \
  --precomputed-vcf-path Data/SpliceAI/whole_genome_filtered_spliceai_scores.vcf.gz
```

Error:
```
[I 200519 14:16:50 __main__:148] Running 'prepare' with args = {'action': 'prepare', 'release': 'GRCh38', 'precomputed_db_path': 'out/precomputed.sqlite3', 'precomputed_vcf_path': 'Data/SpliceAI/whole_genome_filtered_spliceai_scores.vcf.gz'}
[I 200519 14:16:50 __main__:153] Opening database file out/precomputed.sqlite3
Traceback (most recent call last):
  File '/home/user/miniconda3/envs/SpliceAI/bin/spliceai-wrapper', line 12, in <module>
    sys.exit(main())
  File '/home/user/miniconda3/envs/SpliceAI/lib/python3.6/site-packages/spliceai_wrapper/__main__.py', line 469, in main
    return prepare(args)
  File '/home/user/miniconda3/envs/SpliceAI/lib/python3.6/site-packages/spliceai_wrapper/__main__.py', line 154, in prepare
    with closing(sqlite3.connect(args.precomputed_db_path, isolation_level=None)) as con:
TypeError: __init__() got an unexpected keyword argument 'isolation_level'
```